### PR TITLE
Improvements to zinger removal

### DIFF
--- a/src/tomocupy/config.py
+++ b/src/tomocupy/config.py
@@ -356,7 +356,7 @@ SECTIONS['reconstruction'] = {
     'dezinger': {
         'type': int,
         'default': 0,
-        'help': "Radius for removing outliers"},
+        'help': "Width of region for removing outliers"},
     'max-write-threads': {
         'type': int,
         'default': 8,

--- a/src/tomocupy/config.py
+++ b/src/tomocupy/config.py
@@ -357,6 +357,10 @@ SECTIONS['reconstruction'] = {
         'type': int,
         'default': 0,
         'help': "Width of region for removing outliers"},
+    'dezinger-threshold': {
+        'type': int,
+        'default': 5000,
+        'help': "Threshold of grayscale above local median to be considered a zinger pixel"},
     'max-write-threads': {
         'type': int,
         'default': 8,

--- a/src/tomocupy/tomo_functions.py
+++ b/src/tomocupy/tomo_functions.py
@@ -111,10 +111,10 @@ class TomoFunctions():
         if(int(self.args.dezinger) > 0):
             w = int(self.args.dezinger)
             if len(data.shape) == 3:
-                fdata = ndimage.median_filter(data, [1, w, w])
+                fdata = ndimage.median_filter(data, [w, 1, w])
             else:
                 fdata = ndimage.median_filter(data, [w, w])
-            data[:]= cp.where(cp.logical_and(data > fdata, (data - fdata) > 5000), fdata, data)
+            data[:]= cp.where(cp.logical_and(data > fdata, (data - fdata) > self.args.dezinger_threshold), fdata, data)
         return data
 
     def fbp_filter_center(self, data, sht=0):

--- a/src/tomocupy/tomo_functions.py
+++ b/src/tomocupy/tomo_functions.py
@@ -109,14 +109,12 @@ class TomoFunctions():
         """Remove outliers"""
 
         if(int(self.args.dezinger) > 0):
-            r = int(self.args.dezinger)
+            w = int(self.args.dezinger)
             if len(data.shape) == 3:
-                fdata = ndimage.median_filter(data, [1, r, r])
+                fdata = ndimage.median_filter(data, [1, w, w])
             else:
-                fdata = ndimage.median_filter(data, [r, r])
-            import pdb; pdb.set_trace()
+                fdata = ndimage.median_filter(data, [w, w])
             data[:]= cp.where(cp.logical_and(data > fdata, (data - fdata) > 5000), fdata, data)
-            #data[ids] = fdata[ids]
         return data
 
     def fbp_filter_center(self, data, sht=0):


### PR DESCRIPTION
I've changed the logic for zinger removal.  It now acts on the projection, flat, and dark data separately, rather than the dark and flat normalized data.  It looks only for bright pixels (as expected for zingers).  The median kernel acts over angles and columns rather than rows and columns, which more effectively removes zingers at smaller width regions.  I have also added a user-adjustable threshold value and changed the help in the config file to be more explicit.