### PR TITLE
Single-file h5 default, rec_line.txt sidecar, install docs, scipy dep

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -65,7 +65,7 @@ Installation for development
 
 ::
 
-    (base)$ conda create -n tomocupy -c conda-forge cupy scikit-build numexpr opencv tifffile h5py cmake ninja pywavelets python=3.10
+    (base)$ conda create -n tomocupy -c conda-forge cupy scikit-build numexpr opencv tifffile h5py cmake ninja swig scipy pywavelets python=3.10
 
 
 .. warning:: Conda has a built-in mechanism to determine and install the latest version of cudatoolkit supported by your driver. However, if for any reason you need to force-install a particular CUDA version (say 11.0), you can do:
@@ -89,7 +89,34 @@ Installation for development
     (tomocupy)$ cd -
 
 
-6. Make sure that the path to nvcc compiler is set (or set it by e.g. ``export CUDACXX=/local/cuda-11.7/bin/nvcc``) and install tomocupy
+6. Make sure ``nvcc`` is on ``PATH``:
+
+::
+
+    (tomocupy)$ which nvcc
+    (tomocupy)$ nvcc --version
+
+If ``nvcc`` is not found, point at a CUDA toolkit install. Two common setups:
+
+- System CUDA toolkit at e.g. ``/usr/local/cuda-12.1/``:
+
+::
+
+    (tomocupy)$ export CUDAHOME=/usr/local/cuda-12.1
+    (tomocupy)$ export CUDA_PATH=$CUDAHOME
+    (tomocupy)$ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$CUDAHOME/lib64
+    (tomocupy)$ export PATH=$PATH:$CUDAHOME/bin
+
+- NVIDIA HPC SDK loaded via environment modules:
+
+::
+
+    (tomocupy)$ module use /local/nvidia/hpc_sdk/modulefiles
+    (tomocupy)$ module add nvhpc-hpcx-cuda13/26.1
+
+Add the chosen lines to ``~/.bashrc`` to make the setting persistent across logins.
+
+7. Install tomocupy
 
 ::
 
@@ -99,6 +126,9 @@ Installation for development
 
 .. note::
     ``cupy`` must be installed separately via conda (see Step 3) as it is CUDA-version specific and is not declared as a pip dependency.
+
+.. note::
+    The CUDA toolkit (``nvcc``) major version does not need to match ``cupy``'s runtime CUDA version exactly — tomocupy's CUDA kernels are simple enough that minor mismatches (e.g. ``nvcc`` 12.x compiling against a 13.x runtime) typically work. If the build succeeds but the kernels fail at runtime, align the toolkit and runtime to the same major version.
 
 ===================================
 Additional instructions for Windows
@@ -123,6 +153,34 @@ Run the following to check all functionality
 
     (tomocupy)$ cd tests; bash test_all.sh
 
+
+===============
+Troubleshooting
+===============
+
+**Build fails with** ``OSError: [Errno 39] Directory not empty: '_cmake_test_compile/build/CMakeFiles/<version>'``
+
+This is a known race in scikit-build's ``cleanup_test()`` and ``shutil.rmtree`` on the test compile directory. It can happen on the very first ``pip install .`` of a fresh install (not just on retries), and is independent of the Python version. Workaround: clean the partially-written build artifacts and retry. The retry succeeds.
+
+::
+
+    (tomocupy)$ cd tomocupy
+    (tomocupy)$ rm -rf _cmake_test_compile _skbuild build *.egg-info
+    (tomocupy)$ pip install .
+
+**Build fails with** ``CMake Error ... No CMAKE_CUDA_COMPILER could be found``
+
+``nvcc`` is not on ``PATH``. Re-do Step 6 of "Installation for development" (verify with ``which nvcc``) and retry.
+
+**Conda solver picks an incompatible CUDA version**
+
+If your driver supports e.g. CUDA 12.x but conda installs ``cupy`` against a newer cudart, pin the version explicitly:
+
+::
+
+    (base)$ conda create -n tomocupy -c conda-forge cupy scikit-build numexpr opencv tifffile h5py cmake ninja pywavelets cuda-version=12.9 python=3.10
+
+Match the ``cuda-version`` value to what ``nvidia-smi`` reports as the maximum supported.
 
 Update
 ======

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -190,6 +190,37 @@ The installed package lands in your conda env (which is itself on NFS, but insta
 
 ``nvcc`` is not on ``PATH``. Re-do Step 6 of "Installation for development" (verify with ``which nvcc``) and retry.
 
+**Build fails because pip cannot reach PyPI (private/air-gapped network)**
+
+On beamline workstations, HPC login nodes, or other machines without direct internet access, ``pip install .`` fails during the build-dependency fetch step with a timeout or connection error::
+
+    ReadTimeoutError: HTTPSConnectionPool(host='pypi.org', port=443): Read timed out.
+
+Install the build dependencies into the conda env first (only needed once), then build with ``--no-build-isolation`` so pip uses what is already installed instead of fetching from PyPI:
+
+::
+
+    (tomocupy)$ conda install -n tomocupy -c conda-forge scikit-build cmake ninja swig
+    (tomocupy)$ pip install --no-build-isolation .
+
+**Runtime crash: "incomplete type __nv_fp8_e8m0" errors from cupy**
+
+``cupy 14`` bundles CCCL headers that reference ``__nv_fp8_e8m0``, a type introduced in CUDA 12.8. If cupy discovers a system CUDA toolkit older than 12.8 at runtime, every kernel compilation (e.g. inside ``find_center_vo``) fails with a cascade of errors like::
+
+    error: incomplete type "__nv_fp8_e8m0" is not allowed
+
+This happens when ``CUDA_PATH``, ``CUDAHOME``, or ``nvcc`` on ``PATH`` points cupy to the system toolkit instead of its own bundled headers. The fix is to downgrade cupy to a version compatible with your system CUDA:
+
+::
+
+    (base)$ conda install -n tomocupy -c conda-forge cupy=12 cuda-version=<your_system_cuda>
+
+For example, for a system with CUDA 12.1::
+
+    (base)$ conda install -n tomocupy -c conda-forge cupy=12 cuda-version=12.1
+
+To find your system CUDA version run ``nvcc --version`` or ``nvidia-smi``.
+
 **Conda solver picks an incompatible CUDA version**
 
 If your driver supports e.g. CUDA 12.x but conda installs ``cupy`` against a newer cudart, pin the version explicitly:

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -118,11 +118,14 @@ Add the chosen lines to ``~/.bashrc`` to make the setting persistent across logi
 
 7. Install tomocupy
 
+Build on a local (non-NFS) filesystem such as ``/tmp`` or ``/local``. This avoids an NFS silly-rename race in scikit-build's test-compile cleanup that breaks the build when the source tree lives on a shared / NFS-mounted home directory (typical on cluster machines such as APS beamline workstations). The installed package lands in your conda env regardless of where the build happened.
+
 ::
 
-    (tomocupy)$ git clone https://github.com/tomography/tomocupy
-    (tomocupy)$ cd tomocupy
+    (tomocupy)$ git clone https://github.com/tomography/tomocupy /tmp/tomocupy-build
+    (tomocupy)$ cd /tmp/tomocupy-build
     (tomocupy)$ pip install .
+    (tomocupy)$ cd ~ && rm -rf /tmp/tomocupy-build
 
 .. note::
     ``cupy`` must be installed separately via conda (see Step 3) as it is CUDA-version specific and is not declared as a pip dependency.

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -158,15 +158,30 @@ Run the following to check all functionality
 Troubleshooting
 ===============
 
-**Build fails with** ``OSError: [Errno 39] Directory not empty: '_cmake_test_compile/build/CMakeFiles/<version>'``
+**Build fails with** ``OSError: [Errno 39] Directory not empty: 'CMakeFiles'`` **or** ``OSError: [Errno 16] Device or resource busy: '.nfsXXXXXXXX'``
 
-This is a known race in scikit-build's ``cleanup_test()`` and ``shutil.rmtree`` on the test compile directory. It can happen on the very first ``pip install .`` of a fresh install (not just on retries), and is independent of the Python version. Workaround: clean the partially-written build artifacts and retry. The retry succeeds.
+This happens when the source tree is on an **NFS-mounted filesystem** (typical for shared cluster home directories such as ``/home/beams/...`` at APS). scikit-build's ``cleanup_test()`` calls ``shutil.rmtree`` on the test-compile directory while the just-finished CMake test process still has open file handles. NFS does not delete files that are still held open; instead it renames them to ``.nfsXXXXXXXX`` ("silly rename"), which makes ``rmtree`` fail because the directory is "not empty" or the silly-rename file is "busy".
+
+The first ``pip install .`` of a fresh install almost always hits this. The retry succeeds because the file handles from the failed first attempt have closed by the time you re-run, so ``rm -rf`` can fully clear the directory and the second build's cleanup finds it empty.
+
+Workaround (always works):
 
 ::
 
     (tomocupy)$ cd tomocupy
     (tomocupy)$ rm -rf _cmake_test_compile _skbuild build *.egg-info
     (tomocupy)$ pip install .
+
+Permanent alternative — build on a local (non-NFS) filesystem such as ``/tmp`` or ``/local``:
+
+::
+
+    (tomocupy)$ cp -r ~/path/to/tomocupy /tmp/tomocupy-build
+    (tomocupy)$ cd /tmp/tomocupy-build
+    (tomocupy)$ pip install .
+    (tomocupy)$ rm -rf /tmp/tomocupy-build
+
+The installed package lands in your conda env (which is itself on NFS, but install-time writes don't trigger silly-rename because nothing else has those files open).
 
 **Build fails with** ``CMake Error ... No CMAKE_CUDA_COMPILER could be found``
 

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
         'numexpr',
         'numpy',
         'pywavelets',
+        'scipy',
         'tifffile',
         'zarr',
     ]

--- a/src/tomocupy/config.py
+++ b/src/tomocupy/config.py
@@ -454,7 +454,7 @@ SECTIONS['output'] ={
         'choices': ['float32', 'float16'],
         'help': "Data type used for reconstruction. Note float16 works with power of 2 sizes.", },
     'save-format': {
-        'default': 'tiff',
+        'default': 'h5nolinks',
         'type': str,
         'help': "Output format",
         'choices': ['tiff', 'h5', 'h5sino', 'h5nolinks', 'zarr']},

--- a/src/tomocupy/dataio/writer.py
+++ b/src/tomocupy/dataio/writer.py
@@ -109,8 +109,15 @@ class Writer():
                 args.file_name)+'_rec/'+os.path.basename(args.file_name)[:-3]+'_rec'
         else:
             fnameout = str(args.out_path_name)
-        if not os.path.exists(fnameout):
-            os.makedirs(fnameout)
+        if args.save_format in ('h5', 'h5nolinks', 'h5sino'):
+            # output is a .h5 file (with a sibling _parts/ dir for h5/h5sino);
+            # only the parent directory is needed
+            parent_dir = os.path.dirname(fnameout)
+            if parent_dir and not os.path.exists(parent_dir):
+                os.makedirs(parent_dir)
+        else:
+            if not os.path.exists(fnameout):
+                os.makedirs(fnameout)
 
         if (args.clear_folder == 'True'):
             log.info('Clearing the output folder')

--- a/src/tomocupy/dataio/writer.py
+++ b/src/tomocupy/dataio/writer.py
@@ -126,12 +126,6 @@ class Writer():
         if args.save_format == 'tiff':
             # if save results as tiff
             fnameout += '/recon'
-            # saving command line for reconstruction
-            fname_rec_line = os.path.dirname(fnameout)+'/rec_line.txt'
-            rec_line = sys.argv
-            rec_line[0] = os.path.basename(rec_line[0])
-            with open(fname_rec_line, 'w') as f:
-                f.write(' '.join(rec_line))
 
         elif args.save_format == 'h5':
             # if save results as h5 virtual datasets
@@ -231,10 +225,26 @@ class Writer():
                  clean_zarr(self.zarr_output_path)
             log.info(f'Zarr dataset will be created at {fnameout}')
             log.info(f"ZARR chunk structure: {args.zarr_chunk}")
-              
+
+        # CLI invocation log, sibling to the output
+        if args.save_format == 'tiff':
+            rec_line_path = os.path.dirname(fnameout) + '/rec_line.txt'
+        elif args.save_format in ('h5', 'h5nolinks', 'h5sino'):
+            rec_line_path = fnameout[:-3] + '.rec_line.txt'
+        elif args.save_format == 'zarr':
+            rec_line_path = fnameout[:-5] + '.rec_line.txt'
+        self._save_rec_line(rec_line_path)
+
         params.fnameout = fnameout
         log.info(f'Output: {fnameout}')
-        
+
+
+    def _save_rec_line(self, path):
+        rec_line = sys.argv
+        rec_line[0] = os.path.basename(rec_line[0])
+        with open(path, 'w') as f:
+            f.write(' '.join(rec_line))
+
 
     def write_meta(self, rec_virtual):
 


### PR DESCRIPTION
## Summary

This PR collects 8 commits from the `decarlof/tomocupy` fork covering output-format ergonomics, a small bug fix, a packaging fix, and an install-docs expansion based on real-world setup pain on `tomo4` / 2-BM. Files touched: 4 (115 lines in `docs/source/install.rst`, 37 in `writer.py`, plus a one-liner each in `config.py` and `setup.py`).

## Changes

### Output format (user-visible)
- **`feat(config)`: default `--save-format` is now `h5nolinks`** — single self-contained `.h5` out of the box. *Breaking change for anyone relying on the implicit tiff default; pass `--save-format tiff` explicitly to restore the old behavior.*
- **`feat(writer)`: `rec_line.txt` sibling for every save format.** Previously only the tiff branch wrote `rec_line.txt` (the exact CLI used to produce the reconstruction). Extracted into a small `_save_rec_line(path)` helper and added a unified call that picks a sibling path per format:
  - `tiff` → `…_rec/<base>_rec/rec_line.txt` *(unchanged)*
  - `h5` / `h5nolinks` / `h5sino` → `…_rec/<base>_rec.rec_line.txt` next to the `.h5`
  - `zarr` → `…_rec/<base>_rec.rec_line.txt` next to the `.zarr/`
- **`fix(writer)`: don't create an empty `_rec/` subdir for `h5` / `h5nolinks` / `h5sino`.** The h5 variants only need the parent dir; the previously-created per-dataset subdir always stayed empty.

### Build
- **`build`: declare `scipy` as a runtime dependency** in `setup.py`. It was already imported but missing from `install_requires`, so fresh envs without scipy installed independently failed at import time.

### Docs (`docs/source/install.rst`)
- Add swig/scipy explicit-dep notes and expand the nvcc setup section.
- Recommend building on `/tmp` by default (some sites' NFS-mounted home dirs trigger silly-rename behavior during `pip install`).
- Add troubleshooting entries for:
  - NFS silly-rename during build (with the corrected root cause).
  - Private-network builds where `pypi.org` is flaky — use conda + `--no-build-isolation`.
  - cupy / system-CUDA version mismatches (e.g. cupy 14 requiring CUDA 12.8+ for FP8 e8m0).

## Backward compatibility

One breaking change: the default `--save-format` flipped from `tiff` to `h5nolinks`. Anyone calling `tomocupy recon`/`recon_steps` without that flag will now get a single `.h5` instead of a folder of slices. Existing scripts that pass `--save-format` explicitly are unaffected.

## Test plan

- [ ] `tomocupy recon_steps --file-name …` (no `--save-format`) produces a single `<base>_rec.h5` + sibling `<base>_rec.rec_line.txt`, no empty `_rec/` subdir.
- [ ] `tomocupy recon_steps --file-name … --save-format tiff` produces the old layout: `<base>_rec/recon_*.tiff` + `<base>_rec/rec_line.txt`.
- [ ] `--save-format h5` / `h5sino` / `zarr` each produce the expected output plus a sibling `.rec_line.txt`.
- [ ] Fresh conda env install picks up scipy from `install_requires` without a manual `pip install scipy`.
- [ ] `--reconstruction-type try` still writes to `…_rec/try_center/<base>/recon_*.tiff` (unchanged).
