### PR TITLE
h5 output: fix update_hdf_process crash, rename CLI log, NFS docs

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -243,6 +243,32 @@ If your driver supports e.g. CUDA 12.x but conda installs ``cupy`` against a new
 
 Match the ``cuda-version`` value to what ``nvidia-smi`` reports as the maximum supported.
 
+**Runtime crash: HDF5 BlockingIOError when writing output on NFS**
+
+When the reconstruction output (``--save-format h5``, ``h5nolinks``, or ``h5sino``, including the default ``h5nolinks``) is written to an NFS-mounted directory such as ``/data2/2BM/...``, the writer can fail with::
+
+    BlockingIOError: [Errno 11] Unable to synchronously create file
+      (unable to lock file, errno = 11, error message = 'Resource temporarily unavailable')
+
+HDF5 ≥ 1.10 acquires a POSIX file lock before truncating or creating a file, and NFS does not reliably support that locking primitive. The failure rate is highest when an output file from a previous run already exists at the same path — HDF5 must lock it to truncate before re-creating.
+
+Fix: tell HDF5 to skip file locking by setting an environment variable in the ``tomocupy`` conda env:
+
+::
+
+    (tomocupy)$ mkdir -p $CONDA_PREFIX/etc/conda/activate.d
+    (tomocupy)$ echo 'export HDF5_USE_FILE_LOCKING=FALSE' \
+                > $CONDA_PREFIX/etc/conda/activate.d/hdf5_no_lock.sh
+    (tomocupy)$ conda deactivate && conda activate tomocupy
+    (tomocupy)$ echo $HDF5_USE_FILE_LOCKING    # should print: FALSE
+
+Every ``conda activate tomocupy`` shell — including the one tomocupy runs in — will now have the variable set. The setting is the documented HDF5 remedy for NFS; it is safe as long as you are not doing concurrent writes to the same file from multiple processes.
+
+For a one-off shell without changing the env, just export it directly before running::
+
+    (tomocupy)$ export HDF5_USE_FILE_LOCKING=FALSE
+    (tomocupy)$ tomocupy recon_steps ...
+
 Update
 ======
 

--- a/src/tomocupy/config.py
+++ b/src/tomocupy/config.py
@@ -857,8 +857,7 @@ def update_hdf_process(fname, args=None, sections=None):
                     if args and sections and section in sections and hasattr(args, name.replace('-', '_')):
                         value = getattr(args, name.replace('-', '_'))
                         if isinstance(value, list):
-                            # print(type(value), value)
-                            value = ', '.join(value)
+                            value = ', '.join(str(v) for v in value)
                     else:
                         value = opts['default'] if opts['default'] is not None else ''
 

--- a/src/tomocupy/dataio/writer.py
+++ b/src/tomocupy/dataio/writer.py
@@ -230,9 +230,9 @@ class Writer():
         if args.save_format == 'tiff':
             rec_line_path = os.path.dirname(fnameout) + '/rec_line.txt'
         elif args.save_format in ('h5', 'h5nolinks', 'h5sino'):
-            rec_line_path = fnameout[:-3] + '.rec_line.txt'
+            rec_line_path = fnameout[:-3] + '_line.txt'
         elif args.save_format == 'zarr':
-            rec_line_path = fnameout[:-5] + '.rec_line.txt'
+            rec_line_path = fnameout[:-5] + '_line.txt'
         self._save_rec_line(rec_line_path)
 
         params.fnameout = fnameout


### PR DESCRIPTION
Three small follow-ups to the recent merges (#73 h5nolinks default, #74 AI center detection).

## Changes

1. **`fix(config)`: coerce list values to str in `update_hdf_process`.**
   The AI-inference PR added params with `type=list_of_ints`, but `update_hdf_process` called `str.join(value)` without stringifying list elements. **Every `--save-format h5` / `h5nolinks` / `h5sino` reconstruction now crashes with `TypeError: sequence item 0: expected str instance, int found`.** One-line fix.

2. **`fix(writer)`: rename the h5/zarr CLI log file from `<base>_rec.rec_line.txt` to `<base>_rec_line.txt`.** The double extension was awkward in directory listings; single `.txt` suffix is the standard convention. `tiff` layout is unchanged (its `rec_line.txt` lives inside the per-dataset `_rec/` subdir, where the plain name is already unambiguous).

3. **`docs(install)`: troubleshooting entry for HDF5 BlockingIOError on NFS.** Now that `h5nolinks` is the default, anyone writing reconstructions to an NFS-mounted directory (typical at beamlines) will hit HDF5's POSIX-locking failure. Documented the cause and the standard `HDF5_USE_FILE_LOCKING=FALSE` fix as both a permanent (activate.d) and one-off (`export`) recipe.

## Test plan

- [ ] `tomocupy recon_steps … --save-format h5nolinks` (the default) completes without the `TypeError` from `update_hdf_process` on a system where the AI params have non-empty list defaults.
- [ ] Output is `<base>_rec.h5` + sibling `<base>_rec_line.txt` (no double extension).
- [ ] `--save-format tiff` still writes `<base>_rec/rec_line.txt` (unchanged).
- [ ] `--save-format zarr` writes `<base>_rec.zarr/` + sibling `<base>_rec_line.txt`.
- [ ] On an NFS share with the env var unset, the previous `BlockingIOError` reproduces; with `HDF5_USE_FILE_LOCKING=FALSE` set, it does not.
