### PR TITLE
fix(writer): use params.rh as z-dim for lamino h5/h5nolinks output

### DIFF
--- a/src/tomocupy/dataio/writer.py
+++ b/src/tomocupy/dataio/writer.py
@@ -130,9 +130,13 @@ class Writer():
         elif args.save_format == 'h5':
             # if save results as h5 virtual datasets
             fnameout += '.h5'
+            # Recon volume z-dim: lamino runs produce params.rh slices (set by
+            # reader.init_sizes_lamino when args.lamino_angle != 0);
+            # regular tomo produces nzi/2**binning.
+            z_dim = params.rh if args.lamino_angle != 0 else int(params.nzi/2**args.binning)
             # Assemble virtual dataset
             layout = h5py.VirtualLayout(shape=(
-                params.nzi/2**args.binning, params.n, params.n), dtype=params.dtype)
+                z_dim, params.n, params.n), dtype=params.dtype)
             if not os.path.exists(f'{fnameout[:-3]}_parts'):
                 os.makedirs(f'{fnameout[:-3]}_parts')
             for k in range(params.nzchunk):
@@ -167,8 +171,12 @@ class Writer():
         elif args.save_format == 'h5nolinks':
             fnameout += '.h5'
             h5w = h5py.File(fnameout, "w")
+            # Recon volume z-dim: lamino runs produce params.rh slices (set by
+            # reader.init_sizes_lamino when args.lamino_angle != 0);
+            # regular tomo produces nzi/2**binning.
+            z_dim = params.rh if args.lamino_angle != 0 else int(params.nzi/2**args.binning)
             dset_rec = h5w.create_dataset("/exchange/data", shape=(
-                int(params.nzi/2**args.binning), params.n, params.n), dtype=params.dtype)
+                z_dim, params.n, params.n), dtype=params.dtype)
 
             # saving command line to repeat the reconstruction as attribute of /exchange/data
             rec_line = sys.argv


### PR DESCRIPTION
When args.lamino_angle != 0, BackprojLamFourierParallel produces a volume of params.rh slices (size set by reader.init_sizes_lamino). Previously the h5/h5nolinks dataset was created with nzi/2**binning slices, sized for regular tomography, so lamino write_data_chunk calls hit broadcast errors as soon as the volume z-dim differed.

Triggers under the same triple that activates the lamino backprojector in rec_steps.py:108 (lamino_angle != 0 + fourierrec + full); using the reader's lamino-vs-regular branch ensures we match whatever sizing the backprojector actually produces.