### PR TITLE
writer: stop writing _rec_line.txt sidecar for h5 output

### DIFF
--- a/src/tomocupy/dataio/writer.py
+++ b/src/tomocupy/dataio/writer.py
@@ -234,14 +234,18 @@ class Writer():
             log.info(f'Zarr dataset will be created at {fnameout}')
             log.info(f"ZARR chunk structure: {args.zarr_chunk}")
 
-        # CLI invocation log, sibling to the output
+        # CLI invocation log, sibling to the output.
+        # For h5/h5nolinks the command line is already stored as an attribute
+        # of /exchange/data, so the sidecar txt is redundant and skipped.
         if args.save_format == 'tiff':
             rec_line_path = os.path.dirname(fnameout) + '/rec_line.txt'
-        elif args.save_format in ('h5', 'h5nolinks', 'h5sino'):
+            self._save_rec_line(rec_line_path)
+        elif args.save_format == 'h5sino':
             rec_line_path = fnameout[:-3] + '_line.txt'
+            self._save_rec_line(rec_line_path)
         elif args.save_format == 'zarr':
             rec_line_path = fnameout[:-5] + '_line.txt'
-        self._save_rec_line(rec_line_path)
+            self._save_rec_line(rec_line_path)
 
         params.fnameout = fnameout
         log.info(f'Output: {fnameout}')


### PR DESCRIPTION
For h5 and h5nolinks save formats the reconstruction command line is already stored as the `command` attribute on /exchange/data (see lines 154-160 for h5 and 181-187 for h5nolinks), so the sibling _rec_line.txt file is redundant and just adds a second source of truth that can drift or be forgotten when copying the .h5 elsewhere.

The sidecar is still written for:
  - tiff  : no h5 container, so a companion txt is the only record
  - h5sino: the h5sino branch does not attach the `command` attr
  - zarr  : same reasoning as tiff

Downstream tools that previously read only the sidecar (tomolog-cli) should fall back to reading `/exchange/data.attrs[command]` for h5 output; that fallback is being added in tomolog-cli in a companion patch.